### PR TITLE
New grammar rule to include more possible constructions

### DIFF
--- a/espWord.grammar
+++ b/espWord.grammar
@@ -1,8 +1,6 @@
 start_word: (word WHITESPACE+)* word
 
-!word: (((root | prefix | suffix) connective)? (root | prefix | suffix))+  ending
-	 | memstaro
-	 | correlative
+!word: (((root | prefix | suffix | memstaro | correlative) connective?)* (root ending | prefix ending | suffix ending | memstaro ending? | correlative ending?))
 
 !ending: verb
 	   | noun num_and_case

--- a/parseo.py
+++ b/parseo.py
@@ -20,7 +20,7 @@ install(extra_lines=1)
 
 # ----- construct parser for lark -------- #
 
-PATH_PREFIX = "/home/neniu/Projects/eonlp/"
+PATH_PREFIX = "./"
 VORTARO_PATH = PATH_PREFIX + "vortaro.json"
 GRAMMAR_PATH = PATH_PREFIX + "espWord.grammar"
 


### PR DESCRIPTION
In the aim of handling the case of _kaj'o_ (which suffered from the homonymy of the root _kaj_), and then words like _kiom'a_, _kiel'o_, _samkiel_, etc., I mainly redefined the main grammar rule of Esperanto words and I modified the processing of _memstaraĵoj_, especially when they are used as almost normal roots.
I also added some type annotations in order to better understand what was happening, I hope it does not bother you...
I hope that you will find my contribution at least interesting 😁